### PR TITLE
Allow multiple Hosts in AMAZEEIO_URL - amazeeio/haproxy#3

### DIFF
--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -35,9 +35,12 @@ frontend http
   stats uri  /stats
 {{/* We are only interested in containers that have the environment variable AMAZEEIO set */}}
 {{range $key, $container := whereExist $ "Env.AMAZEEIO" }}
-  {{/* Allow containers to set their hostname via the env variable AMAZEEIO_URL if not set, fall bback to the container name */}}
-  {{$host := coalesce $container.Env.AMAZEEIO_URL $container.Name }}
-  use_backend http_{{$host}} if { hdr_dom(host) -i {{$host}} }
+	{{/* Allow containers to set their hostname via the env variable AMAZEEIO_URL if not set, fall bback to the container name */}}
+	{{$hosts := coalesce $container.Env.AMAZEEIO_URL $container.Name }}
+	{{ range $host := split $hosts "," }}
+	{{ $host := trim $host }}
+	use_backend http_{{$host}} if { hdr_dom(host) -i {{$host}} }
+	{{end}}
 {{end}}
 {{/* We are only interested in containers that have the environment variable LAGOON_LOCALDEV_HTTP_PORT set */}}
 {{range $key, $container := whereExist $ "Env.LAGOON_LOCALDEV_HTTP_PORT" }}
@@ -52,8 +55,11 @@ frontend https
   reqadd X-Forwarded-Proto:\ https
   option socket-stats
 {{range $key, $container := whereExist $ "Env.AMAZEEIO" }}
-        {{$host := coalesce $container.Env.AMAZEEIO_URL $container.Name }}
-  use_backend http_{{$host}} if { hdr_dom(host) -i {{$host}} }
+	{{$hosts := coalesce $container.Env.AMAZEEIO_URL $container.Name }}
+	{{ range $host := split $hosts "," }}
+	{{ $host := trim $host }}
+	use_backend https_{{$host}} if { req_ssl_sni -i {{$host}} }
+	{{end}}
 {{end}}
 {{range $key, $container := whereExist $ "Env.LAGOON_LOCALDEV_HTTP_PORT" }}
   {{/* Allow containers to set their hostname via the env variable LAGOON_ROUTE if not set, fall back to the container name and projectname. Also remove http:// and https:// */}}
@@ -62,9 +68,11 @@ frontend https
 {{end}}
 
 {{range $key, $container := whereExist $ "Env.AMAZEEIO" }}
-  {{$host := coalesce $container.Env.AMAZEEIO_URL $container.Name }}
+  {{$hosts := coalesce $container.Env.AMAZEEIO_URL $container.Name }}
   {{/* Allow containers to set their the port for HTTP connections via AMAZEEIO_HTTP_PORT env variable, fallback to Port 80 */}}
   {{$http_port := coalesce $container.Env.AMAZEEIO_HTTP_PORT "80" }}
+  {{ range $host := split $hosts "," }}
+  {{ $host := trim $host }}
 backend http_{{$host}}
   mode http
   {{ $address := where $container.Addresses "Port" $http_port | first }}


### PR DESCRIPTION
recreation of https://github.com/amazeeio/docker-haproxy/pull/3