### PR TITLE
chore: update HAProxy and add specific test

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Build & Publish
+name: Build, Test & Publish
 on:
   push:
     branches:
@@ -114,10 +114,12 @@ jobs:
           docker ps -a --filter "label=pygmy.name"
       - 
         name: Export configuration
-        run: pygmy --config examples/pygmy.basic.yml export -o ./exported-config.yml
+        run: |
+          pygmy --config examples/pygmy.basic.yml export -o ./exported-config.yml
       - 
         name: Show configuration
-        run: cat ./exported-config.yml
+        run: |
+          cat ./exported-config.yml
 #      - 
 #        name: SSH Key test
 #        run: |
@@ -131,6 +133,11 @@ jobs:
           stat /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
           grep "127.0.0.1" /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
           grep "docker.amazee.io" /usr/lib/systemd/resolved.conf.d/docker.amazee.io.conf;
+      -
+        name: haproxy test
+        run: | 
+          curl http://docker.amazee.io/stats | grep 'class=px' | grep 'mailhog.docker.amazee.io';
+          curl http://docker.amazee.io/stats | grep 'HAProxy version';
       - 
         name: Test the amazeeio-network for expected results
         run: |
@@ -160,7 +167,8 @@ jobs:
           docker inspect amazeeio-mailhog   | jq '.[].Config.Labels["pygmy.opensesame"]'  | grep "correct";
       - 
         name: Cowsay test
-        run: pygmy --config examples/pygmy.basic.yml up | grep 'holy ship' || true;
+        run: |
+          pygmy --config examples/pygmy.basic.yml up | grep 'holy ship' || true;
       - 
         name: Test the container image overrides configuration
         run: |
@@ -205,7 +213,8 @@ jobs:
           pygmy --config examples/pygmy.yml status | grep 'Running as container amazeeio-' && true || false;
       - 
         name: Cleanup pygmy
-        run: pygmy clean;
+        run: |
+          pygmy --config examples/pygmy.yml clean;
       - 
         name: Cleanup after tests.
         run: | 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:2.8-alpine3.17
+FROM haproxy:2.9-alpine3.19
 
 USER root
 


### PR DESCRIPTION
This PR updates the HAProxy image to the latest release 2.9, and the latest Alpine base image
https://www.haproxy.com/blog/announcing-haproxy-2-9