### PR TITLE
Raise bufsize to 32kb

### DIFF
--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -15,6 +15,7 @@ global
   daemon
   maxconn 1024
   pidfile /var/run/haproxy.pid
+  tune.bufsize 32768
 
 defaults
   balance roundrobin


### PR DESCRIPTION
Issue: https://github.com/pygmystack/haproxy/issues/31

Nginx has a default `large_client_header_buffers 4 8k;`

My understanding of this is it will allow up to 32kb of headers, with no line exceeding 8kb. 

We have a couple of (rather) large headers, and when combined with cookies, we exceed a total of 16kb in some larger areas of the site. 

HAProxy 🔪 502's the connection.\
HAProxy `bufsize` is `16384` bytes, so any request with headers exceeding that, will fail.

**ISSUE**

HAProxy rejects responses above 16kb, whilst NGINX can handle up to 32kb.

**EXPECTATION**

Within the Pygmy stack, NGINX should be able to return a response.

**SOLUTION**

Raise the total `bufsize` to 32kb

`haproxy.tmpl`

```tmpl
global
  tune.bufsize 32768
```
