### PR TITLE
Upgrade HAProxy to 3.3 and add BATS tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=jwilder/docker-gen:latest /usr/local/bin/docker-gen /usr/local/bin/d
 COPY . /app/
 WORKDIR /app/
 
-ENV DOCKER_HOST unix:///tmp/docker.sock
+ENV DOCKER_HOST=unix:///tmp/docker.sock
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["/app/haproxy_start.sh"]
 EXPOSE 80 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:2.9-alpine3.19
+FROM haproxy:3.3-alpine3.23
 
 USER root
 

--- a/tests/image_structure.bats
+++ b/tests/image_structure.bats
@@ -15,10 +15,12 @@ IMAGE="${IMAGE_NAME:-pygmystack/haproxy:test}"
     [ -n "$output" ]
 }
 
-@test "haproxy version is 3.3.x" {
+@test "haproxy version matches Dockerfile" {
+    local expected_version
+    expected_version="$(grep -oE '^FROM haproxy:[0-9]+\.[0-9]+' "${BATS_TEST_DIRNAME}/../Dockerfile" | grep -oE '[0-9]+\.[0-9]+')"
     run docker run --rm "${IMAGE}" sh -c 'haproxy -v 2>&1'
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "HAProxy version 3.3" ]]
+    [[ "$output" =~ "HAProxy version ${expected_version}" ]]
 }
 
 @test "docker-gen binary is available in PATH" {

--- a/tests/image_structure.bats
+++ b/tests/image_structure.bats
@@ -15,10 +15,10 @@ IMAGE="${IMAGE_NAME:-pygmystack/haproxy:test}"
     [ -n "$output" ]
 }
 
-@test "haproxy version is 2.9.x" {
+@test "haproxy version is 3.3.x" {
     run docker run --rm "${IMAGE}" sh -c 'haproxy -v 2>&1'
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "2.9" ]]
+    [[ "$output" =~ "HAProxy version 3.3" ]]
 }
 
 @test "docker-gen binary is available in PATH" {


### PR DESCRIPTION
This pull request updates the HAProxy base image and its corresponding version check in the test suite to ensure compatibility with the latest release.

**HAProxy version upgrade:**

* Updated the base image in the `Dockerfile` from `haproxy:2.9-alpine3.19` to `haproxy:3.3-alpine3.23` to use the latest HAProxy version and Alpine base.

**Test suite update:**

* Modified the HAProxy version check in `tests/image_structure.bats` to expect version 3.3.x instead of 2.9.x, aligning the test with the upgraded base image.